### PR TITLE
Upgrade startscript-parameters to sbt-native-packager-1.0.0

### DIFF
--- a/startscript-parameters/build.sbt
+++ b/startscript-parameters/build.sbt
@@ -1,13 +1,10 @@
-import com.typesafe.sbt.SbtNativePackager._
-import NativePackagerKeys._
+enablePlugins(JavaServerAppPackaging)
 
 name := "mukis-startscript-parameters"
 
 version := "1.0"
 
 mainClass in Compile := Some("de.mukis.MainApp")
-
-packageArchetype.java_server
 
 maintainer in Debian := "Nepomuk Seiler <nepomuk.seiler@mukis.de>"
 

--- a/startscript-parameters/build.sbt
+++ b/startscript-parameters/build.sbt
@@ -11,3 +11,7 @@ maintainer in Debian := "Nepomuk Seiler <nepomuk.seiler@mukis.de>"
 packageSummary in Linux := "Custom startscript parameters"
 
 packageDescription := "Custom startscript parameters"
+
+rpmVendor := "Nepomuk Seiler"
+
+rpmLicense := Some( "GNU/GPLv3" )

--- a/startscript-parameters/project/build.properties
+++ b/startscript-parameters/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/startscript-parameters/project/plugins.sbt
+++ b/startscript-parameters/project/plugins.sbt
@@ -1,4 +1,4 @@
 // The Typesafe repository 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "0.7.2")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.0.0")

--- a/startscript-parameters/src/main/scala/de/mukis/MainApp.scala
+++ b/startscript-parameters/src/main/scala/de/mukis/MainApp.scala
@@ -15,9 +15,16 @@ object MainApp extends App {
   log newLine ()
   log.close
 
-  val interval = args.indexOf("-interval") match {
-    case i if args.size >= i => args(i + 1).toInt
-    case _                   => 10
+  val interval = {
+    try {
+      args.indexOf( "-interval" ) match {
+        case i if args.size >= i => args( i + 1 ).toInt
+        case _                   => 10
+      }
+    } catch {
+      case e: Exception =>
+        10
+    }
   }
 
   // Creating an executor service to schedule the config parsing

--- a/startscript-parameters/src/templates/etc-default
+++ b/startscript-parameters/src/templates/etc-default
@@ -14,12 +14,4 @@
 # ${{daemon_user}}      daemon user
 # -------------------------------------------------
 
-# Setting memory to 256
-# -mem 256
--J-Xms128m -J-Xmx256m
-# Custom property
--Dde.mukis=my-property
-# Application parameters
--interval 15
-# Use reserved keywords as application parameters (available in 0.7.0 Release)
-# -- -d
+JAVA_OPTS="-Xms129m -Xmx256m"


### PR DESCRIPTION
- Add an exception handler in main
- Modify etc-default with JAVA_OPTS parameter

Can you give me a hint, how I can get arguments to the java commandline? I think, I should can pass for example this parameters:

```
mukis-startscript-parameters +Dde.mukis=Tester -interval 20
```

I want to use it in combination with a akka micro kernel package: 
```
-Dconfig.file=$AKKA_HOME/conf/application.conf
```

Thanks!